### PR TITLE
Remove unnecessary constraints

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+budgie-desktop-view (1.2-2) UNRELEASED; urgency=medium
+
+  * Remove constraints unnecessary since buster:
+    + Build-Depends: Drop versioned constraint on libgtk-3-dev.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Thu, 17 Mar 2022 23:28:10 -0000
+
 budgie-desktop-view (1.2-1) unstable; urgency=medium
 
   [ Debian Janitor ]

--- a/debian/control
+++ b/debian/control
@@ -6,7 +6,7 @@ Build-Depends:
  debhelper (>= 13),
  debhelper-compat (= 13),
  libglib2.0-dev (>= 2.64),
- libgtk-3-dev (>= 3.24.0),
+ libgtk-3-dev,
  meson,
  valac (>= 0.48.0),
  intltool


### PR DESCRIPTION

Remove unnecessary constraints.


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/scrub-obsolete).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/scrub-obsolete.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/scrub-obsolete/pkg/budgie-desktop-view/6b0ec1a8-4629-4f32-9d16-e5edb024f7fc.



## Debdiff

These changes affect the binary packages:


File lists identical (after any substitutions)
### Control files of package budgie-desktop-view: lines which differ (wdiff format)
* Depends: dconf-gsettings-backend | gsettings-backend, libc6 (>= 2.4), libgdk-pixbuf-2.0-0 (>= 2.22.0), libglib2.0-0 (>= 2.64), libgtk-3-0 (>= [-3.24.0)-] {+3.21.5)+}

No differences were encountered between the control files of package \*\*budgie-desktop-view-dbgsym\*\*


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/6b0ec1a8-4629-4f32-9d16-e5edb024f7fc/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/6b0ec1a8-4629-4f32-9d16-e5edb024f7fc/diffoscope)).
