### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+budgie-desktop-view (1.1.1-3) UNRELEASED; urgency=medium
+
+  * Use canonical URL in Vcs-Git.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Sat, 19 Feb 2022 17:14:59 -0000
+
 budgie-desktop-view (1.1.1-2) unstable; urgency=medium
 
   * Bug fix

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,8 @@
 budgie-desktop-view (1.1.1-3) UNRELEASED; urgency=medium
 
   * Use canonical URL in Vcs-Git.
+  * Remove obsolete field Name from debian/upstream/metadata (already present in
+    machine-readable debian/copyright).
 
  -- Debian Janitor <janitor@jelmer.uk>  Sat, 19 Feb 2022 17:14:59 -0000
 

--- a/debian/control
+++ b/debian/control
@@ -12,7 +12,7 @@ Build-Depends:
  intltool
 Standards-Version: 4.6.0
 Vcs-Browser: https://github.com/UbuntuBudgie/budgie-desktop-view/tree/debian
-Vcs-Git: https://github.com/UbuntuBudgie/budgie-desktop-view -b debian
+Vcs-Git: https://github.com/UbuntuBudgie/budgie-desktop-view.git -b debian
 Homepage: https://github.com/buddiesofbudgie/budgie-desktop-view
 Rules-Requires-Root: no
 

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,5 +1,4 @@
 ---
-Name: budgie-desktop-view
 Bug-Database: https://github.com/buddiesofbudgie/budgie-desktop-view
 Cite-As: "Budgie Desktop View is the official Budgie desktop icons application / implementation, developed by Budgie Developers."
 Repository: https://github.com/buddiesofbudgie/budgie-desktop-view.git


### PR DESCRIPTION
Fix some issues reported by lintian

* Use canonical URL in Vcs-Git. ([vcs-field-not-canonical](https://lintian.debian.org/tags/vcs-field-not-canonical))

* Remove obsolete field Name from debian/upstream/metadata (already present in machine-readable debian/copyright).


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/lintian-fixes.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/budgie-desktop-view/4db6ed0f-47c9-40b6-afcd-f37611db612b.



These changes have no impact on the [binary debdiff](
https://janitor.debian.net/api/run/4db6ed0f-47c9-40b6-afcd-f37611db612b/debdiff?filter_boring=1).


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/4db6ed0f-47c9-40b6-afcd-f37611db612b/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/4db6ed0f-47c9-40b6-afcd-f37611db612b/diffoscope)).
