### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -2,6 +2,7 @@ budgie-desktop-view (1.2-2) UNRELEASED; urgency=medium
 
   * Remove constraints unnecessary since buster:
     + Build-Depends: Drop versioned constraint on libgtk-3-dev.
+  * Update standards version to 4.6.1, no changes needed.
 
  -- Debian Janitor <janitor@jelmer.uk>  Thu, 17 Mar 2022 23:28:10 -0000
 

--- a/debian/control
+++ b/debian/control
@@ -10,7 +10,7 @@ Build-Depends:
  meson,
  valac (>= 0.48.0),
  intltool
-Standards-Version: 4.6.0
+Standards-Version: 4.6.1
 Vcs-Browser: https://github.com/UbuntuBudgie/budgie-desktop-view/tree/debian
 Vcs-Git: https://github.com/UbuntuBudgie/budgie-desktop-view.git -b debian
 Homepage: https://github.com/buddiesofbudgie/budgie-desktop-view


### PR DESCRIPTION
Fix some issues reported by lintian

* Use canonical URL in Vcs-Git. ([vcs-field-not-canonical](https://lintian.debian.org/tags/vcs-field-not-canonical))

* Remove obsolete field Name from debian/upstream/metadata (already present in machine-readable debian/copyright).

* Update standards version to 4.6.1, no changes needed. ([out-of-date-standards-version](https://lintian.debian.org/tags/out-of-date-standards-version))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes). For more information, including instructions on how to disable these merge proposals, see https://janitor.debian.net/lintian-fixes.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts or close the merge proposal when all changes are applied through other means (e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at https://janitor.debian.net/lintian-fixes/pkg/budgie-desktop-view/06e5ccee-acd5-4f0b-9f64-000ba9c2b0ad.



These changes have no impact on the [binary debdiff](
https://janitor.debian.net/api/run/06e5ccee-acd5-4f0b-9f64-000ba9c2b0ad/debdiff?filter_boring=1).


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/06e5ccee-acd5-4f0b-9f64-000ba9c2b0ad/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/06e5ccee-acd5-4f0b-9f64-000ba9c2b0ad/diffoscope)).
